### PR TITLE
feat!: add exit-code flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 
 	if analysisResult.TotalDrifted <= 0 {
 		log.Info().Msg("No drifts detected")
-	} else {
+	} else if cfg.ExitCode {
 		os.Exit(1)
 	}
 }

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -37,7 +37,7 @@ func ParseConfig() DriftiveConfig {
 	flag.StringVar(&logLevel, "log-level", "info", "Log level. Options: trace, debug, info, warn, error, fatal, panic")
 	flag.BoolVar(&enableStdoutResult, "stdout", true, "Enable printing drift results to stdout")
 	flag.StringVar(&githubToken, "github-token", "", "Github token")
-	flag.BoolVar(&exitCode, "exit-code", false, "Exit with code 1 if drift is detected")
+	flag.BoolVar(&exitCode, "exit-code", false, "Exit with code 1 if any state drift is detected")
 	flag.Parse()
 
 	validateArgs(repositoryUrl, repositoryPath, branch)

--- a/pkg/config/cli.go
+++ b/pkg/config/cli.go
@@ -27,6 +27,7 @@ func ParseConfig() DriftiveConfig {
 	var logLevel string
 	var enableStdoutResult bool
 	var githubToken string
+	var exitCode bool
 
 	flag.StringVar(&repositoryPath, "repo-path", "", "Path to the repository. If provided, the repository will not be cloned.")
 	flag.StringVar(&repositoryUrl, "repo-url", "", "e.g. https://<token>@github.com/<org>/<repo>. If repo-path is provided, this is ignored.")
@@ -36,6 +37,7 @@ func ParseConfig() DriftiveConfig {
 	flag.StringVar(&logLevel, "log-level", "info", "Log level. Options: trace, debug, info, warn, error, fatal, panic")
 	flag.BoolVar(&enableStdoutResult, "stdout", true, "Enable printing drift results to stdout")
 	flag.StringVar(&githubToken, "github-token", "", "Github token")
+	flag.BoolVar(&exitCode, "exit-code", false, "Exit with code 1 if drift is detected")
 	flag.Parse()
 
 	validateArgs(repositoryUrl, repositoryPath, branch)
@@ -58,5 +60,6 @@ func ParseConfig() DriftiveConfig {
 		SlackWebhookUrl:    slackWebhookUrl,
 		GithubToken:        githubToken,
 		GithubContext:      ghContext,
+		ExitCode:           exitCode,
 	}
 }

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -13,6 +13,7 @@ type DriftiveConfig struct {
 	Concurrency    int    `json:"concurrency" yaml:"concurrency"`
 
 	LogLevel string `json:"log_level" yaml:"log_level"`
+	ExitCode bool   `json:"exit_code" yaml:"exit_code"`
 
 	EnableStdoutResult bool   `json:"stdout_result" yaml:"stdout_result"`
 	SlackWebhookUrl    string `json:"slack_webhook_url" yaml:"slack_webhook_url"`


### PR DESCRIPTION
### Breaking changes
* add `--exit-code` flag  - Driftive will no longer terminate with `exit code = 1` when state drifts are detected per default. To keep the old behavior, use `--exit-code=true`.